### PR TITLE
Use username instead of full-name for stargazers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ $ pipenv run github-stargazers <username>/<repository> [OPTIONS]
 ```
 where `OPTIONS` could be
 ```
---user <username>  User name to see if it is a stargazer. 
-                   username represents the GitHub name.
+--user <username>  GitHub username to see if it is a stargazer. 
 ```
 If it's used without `--user`, it just shows repository's stargazers.
 
@@ -49,7 +48,7 @@ from github_stargazers.github import GitHub
 github = GitHub("yasoob/fb-messenger-bot")
 
 print(github.get_all_stargazers())
-print(github.is_stargazer("Robin"))
+print(github.is_stargazer("Jazzthedog"))
 ```
 
 ## Running from source
@@ -87,8 +86,7 @@ $ pipenv run github-stargazers <username>/<repository> [OPTIONS]
 ```
 where `OPTIONS` could be 
 ```
---user <username>  User name to see if it is a stargazer, 
-                   where username represents the GitHub name. 
+--user <username>  GitHub username to see if it is a stargazer. 
 ```
 
 ### Run autopep8, mypy, pylint for the changed files 

--- a/conftest.py
+++ b/conftest.py
@@ -16,3 +16,12 @@ def http_too_many_requests_status_code() -> int:
 def http_not_found_status_code() -> int:
     return 404
 
+
+@pytest.fixture
+def url_page_content_missing_hyperlink_tag() -> str:
+    return '<h3> foo </h3>'
+
+
+@pytest.fixture
+def url_page_content_missing_href_attribute() -> str:
+    return '<h3> <a> John Williams </a> </h3>'

--- a/github_stargazers/github_stargazers.py
+++ b/github_stargazers/github_stargazers.py
@@ -5,6 +5,7 @@ from halo import Halo
 
 from github_stargazers.github import GitHub
 from github_stargazers.github import UsernameRepositoryError, TooManyRequestsHttpError, UrlNotFoundError
+from github_stargazers.github import MissingHyperlinkTagError, MissingHrefAttributeError
 
 
 class _OutputPrintable(object):
@@ -47,7 +48,8 @@ class _Command:  # pylint: disable=too-few-public-methods
             else:
                 stargazers: typing.List[str] = github.get_all_stargazers()
                 _OutputPrintable.print_stargazers(stargazers)
-        except (TooManyRequestsHttpError, UrlNotFoundError) as exception_message:
+        except (TooManyRequestsHttpError, UrlNotFoundError,
+                MissingHyperlinkTagError, MissingHrefAttributeError) as exception_message:
             Halo().fail(exception_message)
             return None
 

--- a/tests/test_github_stargazers.py
+++ b/tests/test_github_stargazers.py
@@ -10,7 +10,8 @@ from tests import get_examples_invalid_user_repo
 
 @pytest.fixture
 def url_page_content() -> str:
-    return "<h3>foo</h3> <h3>bar</h3>"
+    return '<h3> <a href="/foo"> John Williams </a> </h3> ' \
+           '<h3> <a href="/bar"> Michael Phelps </a> </h3>'
 
 
 @pytest.fixture
@@ -174,3 +175,41 @@ def test_stargazer_on_too_many_requests_page(url_page_content: str,
     )
     result = CliRunner().invoke(command_line, ['foo/bar', '--user', 'foo'])
     verify_invoke_from_clirunner(result, http_too_many_requests)
+
+
+@pytest.fixture
+def missing_hyperlink_tag(halo_fail: str) -> str:
+    return halo_fail + "Missing hyperlink tag.\n"
+
+
+@responses.activate
+def test_stargazer_on_missing_hyperlink_tag(url_page_content_missing_hyperlink_tag: str,
+                                            http_ok_status_code: int,
+                                            missing_hyperlink_tag: str) -> None:
+    responses.add(
+        responses.GET,
+        "https://github.com/foo/bar/stargazers?page=1",
+        body=url_page_content_missing_hyperlink_tag,
+        status=http_ok_status_code
+    )
+    result = CliRunner().invoke(command_line, ['foo/bar', '--user', 'foo'])
+    verify_invoke_from_clirunner(result, missing_hyperlink_tag)
+
+
+@pytest.fixture
+def missing_href_attribute(halo_fail: str) -> str:
+    return halo_fail + "Missing 'href' attribute from hyperlink tag.\n"
+
+
+@responses.activate
+def test_stargazer_on_missing_href_attribute(url_page_content_missing_href_attribute: str,
+                                             http_ok_status_code: int,
+                                             missing_href_attribute: str) -> None:
+    responses.add(
+        responses.GET,
+        "https://github.com/foo/bar/stargazers?page=1",
+        body=url_page_content_missing_href_attribute,
+        status=http_ok_status_code
+    )
+    result = CliRunner().invoke(command_line, ['foo/bar', '--user', 'foo'])
+    verify_invoke_from_clirunner(result, missing_href_attribute)


### PR DESCRIPTION
This PR replaces the usage of GitHub's **full-name** to display _stargazers_ and to check if a user is _stargazer_, with GitHub **username**, making it easier for the users.

Implements https://github.com/marius92mc/github-stargazers/issues/40. 

PTAL @ignacio-chiazzo.