### PR TITLE
Add check for username in href attribute

### DIFF
--- a/github_stargazers/github.py
+++ b/github_stargazers/github.py
@@ -1,5 +1,6 @@
 import typing
 import os
+import re
 
 from bs4 import BeautifulSoup
 from bs4 import element
@@ -40,6 +41,12 @@ class MissingHrefAttributeError(Exception):
 
     def __init__(self) -> None:
         super().__init__("Missing 'href' attribute from hyperlink tag.")
+
+
+class HrefContentError(Exception):
+
+    def __init__(self, href_content: str) -> None:
+        super().__init__(f"Wrong 'href' content: '{href_content}'. It should be of form /username.")
 
 
 class GitHub:
@@ -99,6 +106,9 @@ class GitHub:
                 raise MissingHyperlinkTagError()
             if not hyperlink_component.get('href'):
                 raise MissingHrefAttributeError()
+            href_content: str = hyperlink_component['href']
+            if not re.match(r"/.+$", href_content):
+                raise HrefContentError(href_content)
 
         def _extract_username_from_h3(component: element.Tag) -> typing.Optional[str]:
             if component.get_text() == self.__MARK_END_OF_STARGAZERS:

--- a/github_stargazers/github.py
+++ b/github_stargazers/github.py
@@ -101,6 +101,19 @@ class GitHub:
         h3_components: element.ResultSet = soup.find_all('h3')
 
         def _check_hyperlink_component(component: element.Tag) -> None:
+            """Check the BeautifulSoup `element.Tag` component that receives a hyperlink HTML tag.
+
+            The expected structure is as follows:
+            '<h3> <a href="/foo"> John Williams </a> </h3>'
+            It incrementally dives into the component one tag or attribute of a tag at a time, making sure they appear:
+            - the hyperlink tag: <a>
+            - the `href` attribute: <a href="..."> </a>
+            - the content of hyperlink's `href` attribute.
+            The href content contains the GitHub username prefixed by the '/' character, with the following form:
+            `/username`.
+
+            If any of the above mentioned is missing or not in the expected form, an Exception is raised.
+            """
             hyperlink_component: typing.Optional[element.Tag] = component.find('a')
             if not hyperlink_component:
                 raise MissingHyperlinkTagError()

--- a/github_stargazers/github_stargazers.py
+++ b/github_stargazers/github_stargazers.py
@@ -5,7 +5,7 @@ from halo import Halo
 
 from github_stargazers.github import GitHub
 from github_stargazers.github import UsernameRepositoryError, TooManyRequestsHttpError, UrlNotFoundError
-from github_stargazers.github import MissingHyperlinkTagError, MissingHrefAttributeError
+from github_stargazers.github import MissingHyperlinkTagError, MissingHrefAttributeError, HrefContentError
 
 
 class _OutputPrintable(object):
@@ -49,7 +49,7 @@ class _Command:  # pylint: disable=too-few-public-methods
                 stargazers: typing.List[str] = github.get_all_stargazers()
                 _OutputPrintable.print_stargazers(stargazers)
         except (TooManyRequestsHttpError, UrlNotFoundError,
-                MissingHyperlinkTagError, MissingHrefAttributeError) as exception_message:
+                MissingHyperlinkTagError, MissingHrefAttributeError, HrefContentError) as exception_message:
             Halo().fail(exception_message)
             return None
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,3 +7,11 @@ def get_examples_invalid_user_repo() -> typing.List[str]:
         "foo/another_bar",
         "another_foo/another_bar"
     ]
+
+
+def get_wrong_href_content() -> typing.List[str]:
+    return ["/", "a", "baz"]
+
+
+def get_page_content_with_href(href: str) -> str:
+    return '<h3> <a href="' + href + '"> John Williams </a> </h3>'

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -4,8 +4,8 @@ import responses
 
 from github_stargazers.github import GitHub
 from github_stargazers.github import UsernameRepositoryError, TooManyRequestsHttpError, UrlNotFoundError
-from github_stargazers.github import MissingHyperlinkTagError, MissingHrefAttributeError
-from tests import get_examples_invalid_user_repo
+from github_stargazers.github import MissingHyperlinkTagError, MissingHrefAttributeError, HrefContentError
+from tests import get_examples_invalid_user_repo, get_wrong_href_content, get_page_content_with_href
 
 
 def test_wrong_argument_raises() -> None:
@@ -216,4 +216,18 @@ def test_provided_user_with_missing_href_attribute(url_page_content_missing_href
         status=http_ok_status_code
     )
     with pytest.raises(MissingHrefAttributeError):
+        GitHub("foo/bar").is_stargazer("foo")
+
+
+@pytest.mark.parametrize("wrong_href_content", get_wrong_href_content())
+@responses.activate
+def test_wrong_href_content_raises(wrong_href_content: str,
+                                   http_ok_status_code: int) -> None:
+    responses.add(
+        responses.GET,
+        "https://github.com/foo/bar/stargazers?page=1",
+        body=get_page_content_with_href(wrong_href_content),
+        status=http_ok_status_code
+    )
+    with pytest.raises(HrefContentError):
         GitHub("foo/bar").is_stargazer("foo")


### PR DESCRIPTION
In the nested check function from `__extract_stargazers_from_url()` for the hyperlink's href content we didn't make sure that the username is of form `/username` before using [that](https://github.com/marius92mc/github-stargazers/blob/8246ce281979e8a2372639e4b08548996eb4f5e2/github_stargazers/github.py#L107) string. 

This PR introduces this check step. 

PTAL @ignacio-chiazzo 